### PR TITLE
Restore location after devtools reset

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,10 @@ function updatePath(path, noRouterUpdate) {
 
 // Reducer
 
-const initialState = {};
+const initialState = typeof window === undefined ? {} : {
+  path: locationToString(window.location)
+};
+
 function update(state=initialState, action) {
   if(action.type === UPDATE_PATH) {
     return Object.assign({}, state, {


### PR DESCRIPTION
I found a problem with Devtools where a 'RESET' will change the path to '/' regardless of the initial URL. This is the quick workaround I am currently using, but I wonder if there is a better way.