### PR TITLE
Eliminate double ? from routing.path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,9 +29,7 @@ function update(state=initialState, action) {
 // Syncing
 
 function locationToString(location) {
-  return location.pathname +
-    (location.search ? ('?' + location.search) : '') +
-    (location.hash ? ('#' + location.hash) : '');
+  return location.pathname + location.search + location.hash;
 }
 
 function syncReduxAndRouter(history, store) {


### PR DESCRIPTION
I was getting double ? before the query string in routing.path. I think this is because the location.query already has a ? in the front (and the same applies for hash). I removed the '?' that was being prepended which seems to fix the problem unless there are some edge cases I am missing. 