### PR TITLE
Allow users to provide custom selectRouterState

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 // constants
 
 const UPDATE_PATH = "@@router/UPDATE_PATH";
+const SELECT_STATE = (state) => state.routing;
 
 // Action creator
 
@@ -35,19 +36,19 @@ function locationToString(location) {
   return location.pathname + location.search + location.hash;
 }
 
-function syncReduxAndRouter(history, store, prop='routing') {
-  const getRouterState = () => store.getState()[prop];
+function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
+  const getRouterState = () => selectRouterState(store.getState());
 
   if(!getRouterState()) {
     throw new Error(
       "Cannot sync router: route state does not exist. Did you " +
-      "install the reducer under the name `" + prop + "`?"
+      "install the reducer under the name `routing`?"
     );
   }
 
   const unsubscribeHistory = history.listen(location => {
     // Avoid dispatching an action if the store is already up-to-date,
-    // even if `history` wouldn't do anthing if the location is the same
+    // even if `history` wouldn't do anything if the location is the same
     if(getRouterState().path !== locationToString(location)) {
       store.dispatch(updatePath(locationToString(location)));
     }

--- a/src/index.js
+++ b/src/index.js
@@ -35,24 +35,27 @@ function locationToString(location) {
   return location.pathname + location.search + location.hash;
 }
 
-function syncReduxAndRouter(history, store) {
-  if(!store.getState().routing) {
+function syncReduxAndRouter(history, store, prop='routing') {
+  const getRouterState = () => store.getState()[prop];
+
+  if(!getRouterState()) {
     throw new Error(
       "Cannot sync router: route state does not exist. Did you " +
-      "install the reducer under the name `routing`?"
+      "install the reducer under the name `" + prop + "`?"
     );
   }
 
   const unsubscribeHistory = history.listen(location => {
     // Avoid dispatching an action if the store is already up-to-date,
-    // even if `history` wouldn't do anything if the location is the same
-    if(store.getState().routing.path !== locationToString(location)) {
+    // even if `history` wouldn't do anthing if the location is the same
+    if(getRouterState().path !== locationToString(location)) {
       store.dispatch(updatePath(locationToString(location)));
     }
   });
 
   const unsubscribeStore = store.subscribe(() => {
-    const routing = store.getState().routing;
+    const routing = getRouterState();
+
     // Don't update the router if nothing has changed. The
     // `noRouterUpdate` flag can be set to avoid updating altogether,
     // which is useful for things like loading snapshots or very special


### PR DESCRIPTION
I have no idea if this is desirable or not, but figured I'd give it a shot just in case. I have a few projects with redux-router that are candidates for conversion to redux-simple-router, and it would be nice to be able to customize what the name of the property is on the store to maintain consistency.

If this is in fact something that might make sense but you can think of a more elegant implementation, I'm all ears. If not, I understand.

Thanks for a cool project.