### PR TITLE
Replace es2015 Object.assign for non es2015 environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "mkdir -p lib && babel ./src/index.js --presets babel-preset-es2015 --out-file ./lib/index.js",
+    "build": "mkdir -p lib && babel ./src/index.js --plugins transform-object-assign --presets babel-preset-es2015 --out-file ./lib/index.js",
     "prepublish": "npm run build"
   },
   "tags": [
@@ -26,6 +26,7 @@
   ],
   "devDependencies": {
     "babel-cli": "^6.1.2",
+    "babel-plugin-transform-object-assign": "^6.0.14",
     "babel-preset-es2015": "^6.1.2"
   }
 }


### PR DESCRIPTION
When I tried using this library in a node 0.12.7 environment, my server side code failed due to Object.assign not being present.  Since the source is already being transpiled with es2016 presets, it seems to make sense to also replace Object.assign when not available.