### PR TITLE
add setTimeout to syncReduxAndRouter's store listener so we go last

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,15 +52,19 @@ function syncReduxAndRouter(history, store) {
   });
 
   const unsubscribeStore = store.subscribe(() => {
-    const routing = store.getState().routing;
-    // Don't update the router if nothing has changed. The
-    // `noRouterUpdate` flag can be set to avoid updating altogether,
-    // which is useful for things like loading snapshots or very special
-    // edge cases.
-    if(routing.path !== locationToString(window.location) &&
-       !routing.noRouterUpdate) {
-      history.pushState(null, routing.path);
-    }
+    // Wait until all other listeners have fired and all react components are updated
+    // before triggering the new route; this ensures they all have the new data first.
+    setTimeout(function() {
+      const routing = store.getState().routing;
+      // Don't update the router if nothing has changed. The
+      // `noRouterUpdate` flag can be set to avoid updating altogether,
+      // which is useful for things like loading snapshots or very special
+      // edge cases.
+      if(routing.path !== locationToString(window.location) &&
+         !routing.noRouterUpdate) {
+        history.pushState(null, routing.path);
+      }
+    }, 0);
   });
 
   return function unsubscribe() {


### PR DESCRIPTION
First of all, thank you so much for this great example of minimalism. Playing around with this yesterday and today, I ran into an issue where, on a transition caused by changing the path in state directly, I would see the target views rendered twice. More importantly, the first time they would fail, and the second time they would succeed.

The issue is this: `react-redux`'s higher-order React components installed via `connect()` only subscribe to state changes on `componentDidMount`, which means that they are guaranteed to be _after_ the listener installed by `redux-simple-router`'s `syncReduxAndRouter`. And that means we'll fire a history transition before any React components have the new data. And if those React components assume certain data will be there, you'll get a crash, like I did.

This change introduces a `setTimeout` into the state listener installed by `syncReduxAndRouter`, to ensure that it runs only after all the other store listeners have run.