### PR TITLE
Handle routing state and replace

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "isparta": "^4.0.0",
     "mocha": "^2.3.4",
     "redux": "^3.0.4"
+  },
+  "dependencies": {
+    "deep-equal": "^1.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,28 @@
+const deepEqual = require('deep-equal');
 
-// constants
+// Constants
 
 const UPDATE_PATH = "@@router/UPDATE_PATH";
 const SELECT_STATE = state => state.routing;
 
 // Action creator
 
-function updatePath(path, avoidRouterUpdate) {
+function pushPath(path, state, avoidRouterUpdate) {
   return {
     type: UPDATE_PATH,
     path: path,
+    state: state,
+    replace: false,
+    avoidRouterUpdate: !!avoidRouterUpdate
+  };
+}
+
+function replacePath(path, state, avoidRouterUpdate) {
+  return {
+    type: UPDATE_PATH,
+    path: path,
+    state: state,
+    replace: true,
     avoidRouterUpdate: !!avoidRouterUpdate
   }
 }
@@ -18,16 +31,18 @@ function updatePath(path, avoidRouterUpdate) {
 
 const initialState = {
   changeId: 1,
-  path: (typeof window !== 'undefined') ?
-    locationToString(window.location) :
-    '/'
+  path: undefined,
+  state: undefined,
+  replace: false
 };
 
 function update(state=initialState, action) {
   if(action.type === UPDATE_PATH) {
     return Object.assign({}, state, {
       path: action.path,
-      changeId: state.changeId + (action.avoidRouterUpdate ? 0 : 1)
+      changeId: state.changeId + (action.avoidRouterUpdate ? 0 : 1),
+      state: action.state,
+      replace: action.replace
     });
   }
   return state;
@@ -35,8 +50,8 @@ function update(state=initialState, action) {
 
 // Syncing
 
-function locationToString(location) {
-  return location.pathname + location.search + location.hash;
+function locationsAreEqual(a, b) {
+  return a.path === b.path && deepEqual(a.state, b.state);
 }
 
 function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
@@ -50,25 +65,36 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
     );
   }
 
-  const unsubscribeHistory = history.listen(location => {
-    const routePath = locationToString(location);
+  let historyLocation = {};
 
-    // Avoid dispatching an action if the store is already up-to-date
-    if(getRouterState().path !== routePath) {
-      store.dispatch(updatePath(routePath, { avoidRouterUpdate: true }));
-    }
+  const unsubscribeHistory = history.listen(location => {
+    historyLocation = {
+      path: history.createPath(location),
+      state: location.state
+    };
+
+    const routing = getRouterState();
+ 
+    // Avoid dispatching an action if the store is already up-to-date,
+    // even if `history` wouldn't do anything if the location is the same
+    if(locationsAreEqual(routing, historyLocation)) return;
+
+    store.dispatch(pushPath(historyLocation.path, historyLocation.state, { avoidRouterUpdate: true }));
   });
 
   const unsubscribeStore = store.subscribe(() => {
     const routing = getRouterState();
 
-    // Only update the router once per `updatePath` call. This is
+    // Only update the router once per `pushPath` call. This is
     // indicated by the `changeId` state; when that number changes, we
-    // should call `pushState`.
-    if(lastChangeId !== routing.changeId) {
-      lastChangeId = routing.changeId;
-      history.pushState(null, routing.path);
-    }
+    // should update the history.
+    if(lastChangeId === routing.changeId) return;
+
+    lastChangeId = routing.changeId;
+
+    const method = routing.replace ? 'replaceState' : 'pushState';
+
+    history[method](routing.state, routing.path);
   });
 
   return function unsubscribe() {
@@ -79,7 +105,8 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
 
 module.exports = {
   UPDATE_PATH,
-  updatePath,
+  pushPath,
+  replacePath,
   syncReduxAndRouter,
   routeReducer: update
 };

--- a/src/index.js
+++ b/src/index.js
@@ -68,18 +68,16 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
   }
 
   const unsubscribeHistory = history.listen(location => {
-    const historyLocation = {
+    const route = {
       path: history.createPath(location),
       state: location.state
     };
 
-    const routing = getRouterState();
- 
     // Avoid dispatching an action if the store is already up-to-date,
     // even if `history` wouldn't do anything if the location is the same
-    if(locationsAreEqual(routing, historyLocation)) return;
+    if(locationsAreEqual(getRouterState(), route)) return;
 
-    store.dispatch(pushPath(historyLocation.path, historyLocation.state, { avoidRouterUpdate: true }));
+    store.dispatch(pushPath(route.path, route.state, { avoidRouterUpdate: true }));
   });
 
   const unsubscribeStore = store.subscribe(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -67,10 +67,8 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
     );
   }
 
-  let historyLocation = {};
-
   const unsubscribeHistory = history.listen(location => {
-    historyLocation = {
+    const historyLocation = {
       path: history.createPath(location),
       state: location.state
     };

--- a/src/index.js
+++ b/src/index.js
@@ -7,23 +7,25 @@ const SELECT_STATE = state => state.routing;
 
 // Action creator
 
-function pushPath(path, state, avoidRouterUpdate) {
+function pushPath(path, state, opts) {
+  opts = opts || {};
   return {
     type: UPDATE_PATH,
     path: path,
     state: state,
     replace: false,
-    avoidRouterUpdate: !!avoidRouterUpdate
+    avoidRouterUpdate: !!opts.avoidRouterUpdate
   };
 }
 
-function replacePath(path, state, avoidRouterUpdate) {
+function replacePath(path, state, opts) {
+  opts = opts || {};
   return {
     type: UPDATE_PATH,
     path: path,
     state: state,
     replace: true,
-    avoidRouterUpdate: !!avoidRouterUpdate
+    avoidRouterUpdate: !!opts.avoidRouterUpdate
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,14 @@ describe('replacePath', () => {
       replace: true,
       avoidRouterUpdate: true
     });
+
+    expect(replacePath('/foo', undefined, { avoidRouterUpdate: false })).toEqual({
+      type: UPDATE_PATH,
+      path: '/foo',
+      state: undefined,
+      replace: true,
+      avoidRouterUpdate: false
+    });
   });
 });
 


### PR DESCRIPTION
A couple of different changes here. Could split into multiple PRs, but wanted to see if you're interested first (I've also of course seen the PRs that already exist, but just copied this from the changes I needed for my app)

The changes:

- No longer use `window.location`, always rely on the `location` we receive from `history`
- Because of the above, let the initial state not be the current url, but set is with `noRouterUpdate=true`
- Add handling of `location.state` (and therefore a deep equal check when comparing locations)
- Use `history.createPath` instead of `locationToString`
- Make it possible to replace in addition to push

Also thought about renaming, but didn't for this PR:

- `updatePath` to `pushPath` (closer to `history.push` and `history.replace`)
- `noRouterUpdate` to `skipUpdate` or `noUpdate`
- `syncReduxAndRouter` to `syncReduxAndHistory`