### PR TITLE
Ensure correct push/replace state in store

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,11 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
     // even if `history` wouldn't do anything if the location is the same
     if(locationsAreEqual(getRouterState(), route)) return;
 
-    store.dispatch(pushPath(route.path, route.state, { avoidRouterUpdate: true }));
+    const updatePath = location.action === 'REPLACE'
+      ? replacePath
+      : pushPath;
+
+    store.dispatch(updatePath(route.path, route.state, { avoidRouterUpdate: true }));
   });
 
   const unsubscribeStore = store.subscribe(() => {

--- a/test/index.js
+++ b/test/index.js
@@ -116,28 +116,35 @@ describe('syncReduxAndRouter', () => {
     history.pushState(null, '/foo');
     expect(store.getState().routing.path).toEqual('/foo');
     expect(store.getState().routing.state).toBe(null);
+    expect(store.getState().routing.replace).toBe(false);
 
     history.pushState({ bar: 'baz' }, '/foo');
     expect(store.getState().routing.path).toEqual('/foo');
     expect(store.getState().routing.state).toEqual({ bar: 'baz' });
+    expect(store.getState().routing.replace).toBe(true);
 
     history.replaceState(null, '/bar');
     expect(store.getState().routing.path).toEqual('/bar');
     expect(store.getState().routing.state).toBe(null);
+    expect(store.getState().routing.replace).toBe(true);
 
     history.pushState(null, '/bar');
     expect(store.getState().routing.path).toEqual('/bar');
     expect(store.getState().routing.state).toBe(null);
+    expect(store.getState().routing.replace).toBe(true);
 
     history.pushState(null, '/bar?query=1');
     expect(store.getState().routing.path).toEqual('/bar?query=1');
+    expect(store.getState().routing.replace).toBe(false);
 
     history.replaceState({ bar: 'baz' }, '/bar?query=1');
     expect(store.getState().routing.path).toEqual('/bar?query=1');
     expect(store.getState().routing.state).toEqual({ bar: 'baz' });
+    expect(store.getState().routing.replace).toBe(true);
 
-    history.pushState(null, '/bar?query=1#hash=2');
+    history.pushState({ bar: 'baz' }, '/bar?query=1#hash=2');
     expect(store.getState().routing.path).toEqual('/bar?query=1#hash=2');
+    expect(store.getState().routing.replace).toBe(true);
   });
 
   it('syncs redux -> router', () => {


### PR DESCRIPTION
I think we should be consistent about having `replace` correct in the store. It doesn't change much, but it _might_ be relevant if you play around with `UPDATE_PATH` in a reducer.

As far as I can tell `history` treats same url but different state as a replace:

```
history.pushState(null, '/foo');
// to
history.pushState({ bar: 'baz' }, '/foo');
```

I'm also open to just skip this one if we don't want the added "complexity".