### PR TITLE
use `exports` to be consumable by es6 transpilers (e.g. babel6)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,10 +107,8 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
   };
 }
 
-module.exports = {
-  UPDATE_PATH,
-  pushPath,
-  replacePath,
-  syncReduxAndRouter,
-  routeReducer: update
-};
+exports.UPDATE_PATH = UPDATE_PATH;
+exports.pushPath = pushPath;
+exports.replacePath = replacePath;
+exports.syncReduxAndRouter = syncReduxAndRouter;
+exports.routeReducer = update


### PR DESCRIPTION
I could have just confused myself, but I believe Babel 6 changed the way cjs files are resolved with named `import` statements in es6. This change meant that cjs files that assigned objects to `module.exports` cannot be destructured within the import statement and results in a `Module <whatever> does not export <named-export>` error. The solution, it appears, is to assign values to properties on the `exports` object rather than a single object assigned to `module.exports`. Again, I may wrong on what exactly is happening, but it solved the problem for me and all tests pass. Feel free to reject with prejudice if I'm out of my mind. Thanks for the work!