### PR TITLE
Get devtools working

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.4",
     "redux": "^3.0.4",
+    "redux-devtools": "^2.1.5",
     "webpack": "^1.12.9"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -112,8 +112,12 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
       routing = firstRoute;
     }
 
-    if(lastRoute !== undefined && lastRoute.changeId === routing.changeId) {
-      if(locationsAreEqual(routing, lastRoute)) return;
+    // Only trigger history update is this is a new change or the location
+    // has changed.
+    if(lastRoute !== undefined &&
+      lastRoute.changeId === routing.changeId &&
+      locationsAreEqual(lastRoute, routing)) {
+      return;
     }
 
     lastRoute = routing;

--- a/src/index.js
+++ b/src/index.js
@@ -55,12 +55,26 @@ function update(state=initialState, { type, payload }) {
 // Syncing
 
 function locationsAreEqual(a, b) {
-  return a.path === b.path && deepEqual(a.state, b.state);
+  return a != null && b != null && a.path === b.path && deepEqual(a.state, b.state);
 }
 
 function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
   const getRouterState = () => selectRouterState(store.getState());
-  let lastChangeId = 0;
+
+  // Because we're not able to set the initial path in `initialState` we need a
+  // "hack" to get "Revert" in Redux DevTools to work. We solve this by keeping
+  // the first route so we can revert to this route when the initial state is
+  // replayed to reset the state. Basically, we treat the first route as our
+  // initial state.
+  let firstRoute = undefined;
+
+  // To properly handle store updates we need to track the last route. This
+  // route contains a `changeId` which is updated on every `pushPath` and
+  // `replacePath`. If this id changes we always trigger a history update.
+  // However, if the id does not change, we check if the location has changed,
+  // and if it is we trigger a history update. (If these are out of sync it's
+  // likely because of React DevTools.)
+  let lastRoute = undefined;
 
   if(!getRouterState()) {
     throw new Error(
@@ -75,6 +89,10 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
       state: location.state
     };
 
+    if (firstRoute === undefined) {
+      firstRoute = route;
+    }
+
     // Avoid dispatching an action if the store is already up-to-date,
     // even if `history` wouldn't do anything if the location is the same
     if(locationsAreEqual(getRouterState(), route)) return;
@@ -87,14 +105,18 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
   });
 
   const unsubscribeStore = store.subscribe(() => {
-    const routing = getRouterState();
+    let routing = getRouterState();
 
-    // Only update the router once per `pushPath` call. This is
-    // indicated by the `changeId` state; when that number changes, we
-    // should update the history.
-    if(lastChangeId === routing.changeId) return;
+    // Treat `firstRoute` as our `initialState`
+    if(routing === initialState) {
+      routing = firstRoute;
+    }
 
-    lastChangeId = routing.changeId;
+    if(lastRoute !== undefined && lastRoute.changeId === routing.changeId) {
+      if(locationsAreEqual(routing, lastRoute)) return;
+    }
+
+    lastRoute = routing;
 
     const method = routing.replace ? 'replaceState' : 'pushState';
 


### PR DESCRIPTION
This is a WIP based on #70. With this change both devtools and the tests run (I didn't remove `changeId`, so might be there are something in the tests that actually isn't working as expected, of course). It solves the problems in https://github.com/jlongster/redux-simple-router/issues/61, as far as I can see.

Anyone else want to play around with it? Checkout this PR (help in https://help.github.com/articles/checking-out-pull-requests-locally/), copy in these changes, then run `npm run build` in root and then run `npm start` in `examples/basic/`, then open up `examples/basic/index.html` and test.

@jlongster Thoughts on https://github.com/kjbekkelund/redux-simple-router/commit/ef42b0fee67b048227b578652c69b4906492d389? Might be the change from `changeId` has broken something subtle. The tests should probably rely less on checking these ids, and instead focus on the actual `store` and `history` changes. That way we can change the internal implementation and still be sure the code does what it should (i.e. its external api).