### PR TITLE
Don't navigate immediately on boot.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
 
     // Only trigger history update is this is a new change or the location
     // has changed.
-    if(lastRoute !== undefined &&
+    if(lastRoute === undefined ||
       lastRoute.changeId === routing.changeId &&
       locationsAreEqual(lastRoute, routing)) {
       return;


### PR DESCRIPTION
Had an issue in my app, in combination with `react-fetcher`, where `redux-simple-router` would create a history navigation on load, even though there's no reason to immediately navigate right on boot (the url is already in the URL bar).

Was this behavior intentional? Changing this line fixed the issue for me and I no longer have a redundant `UPDATE_PATH` on boot and an additional fetch.

If it helps, I'm pairing this with populating `state.routing.path` on the server side using `req.url`, so the routing path is correctly pre-populated on boot.