### PR TITLE
Fix basename path issues

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,16 @@ function locationsAreEqual(a, b) {
   return a != null && b != null && a.path === b.path && deepEqual(a.state, b.state)
 }
 
+function createPath(location) {
+  const { pathname, search, hash } = location
+  let result = pathname
+  if (search)
+    result += search
+  if (hash)
+    result += hash
+  return result
+}
+
 function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
   const getRouterState = () => selectRouterState(store.getState())
 
@@ -92,7 +102,7 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
 
   const unsubscribeHistory = history.listen(location => {
     const route = {
-      path: history.createPath(location),
+      path: createPath(location),
       state: location.state
     }
 

--- a/test/createTests.js
+++ b/test/createTests.js
@@ -5,6 +5,7 @@ const { pushPath, replacePath, UPDATE_PATH, routeReducer, syncReduxAndRouter } =
 const { createStore, combineReducers, compose } = require('redux')
 const { devTools } = require('redux-devtools')
 const { ActionCreators } = require('redux-devtools/lib/devTools')
+const { useBasename } = require('history')
 
 expect.extend({
   toContainRoute({
@@ -600,6 +601,22 @@ module.exports = function createTests(createHistory, name, reset = defaultReset)
         expect(
           () => store.dispatch(pushPath('/foo'))
         ).toNotThrow()
+      })
+    })
+
+    it('handles basename history option', () => {
+      const store = createStore(combineReducers({
+        routing: routeReducer
+      }))
+      const history = useBasename(createHistory)({ basename:'/foobar' })
+      syncReduxAndRouter(history, store)
+
+      store.dispatch(pushPath('/bar'))
+      expect(store).toContainRoute({
+        path: '/bar',
+        changeId: 2,
+        replace: false,
+        state: undefined
       })
     })
   })


### PR DESCRIPTION
Closes #102 #103 

The problem with relying on `history.createPath` is that it might change in ways we don't want it to, e.g. as here when `history.createPath` prepends the basename, which means that the input to `pushPath` will differ from the path we create on a location change.

I think a good first step is to create the path ourselves (as we did in the previous version), and going forward to think about the ideas in #95 for later versions.

Thanks @dtryon and @hunterc for helping to fix this