### PR TITLE
Rely less on changeId in tests

### DIFF
--- a/test/createTests.js
+++ b/test/createTests.js
@@ -489,7 +489,7 @@ module.exports = function createTests(createHistory, name, reset = defaultReset)
         ).toNotThrow()
       })
 
-      it('only triggers once when updating path via store', () => {
+      it('only triggers history once when updating path via store', () => {
         const updates = []
         const historyUnsubscribe = history.listen(location => {
           updates.push(location.pathname);
@@ -500,6 +500,20 @@ module.exports = function createTests(createHistory, name, reset = defaultReset)
         expect(updates).toEqual(['/', '/bar', '/baz'])
 
         historyUnsubscribe()
+      })
+
+      it('only triggers store once when updating path via store', () => {
+        const updates = []
+        const storeUnsubscribe = store.subscribe(() => {
+          updates.push(store.getState().routing.path);
+        })
+
+        store.dispatch(pushPath('/bar'));
+        store.dispatch(pushPath('/baz'));
+        store.dispatch(replacePath('/foo'));
+        expect(updates).toEqual(['/bar', '/baz', '/foo'])
+
+        storeUnsubscribe()
       })
     })
 


### PR DESCRIPTION
Tried to clean up the tests so they have less duplication and rely less on checking `changeId`, but focus more on checking what actually triggers `history.listen` (i.e. the external api for these changes). This should make it easier to tests changes to how we stop cycles.

I removed the test named "does not unnecessarily update the store", but added a "only triggers once when updating path via store" (which I created as part of #109, where I have a test which covers `history.pushState`).